### PR TITLE
security: harden CI workflows with SHA-pinned actions and dep-guard

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -2,6 +2,7 @@ name: CI tests
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - main
@@ -10,7 +11,13 @@ env:
   GO_VERSION: "1.24"
 
 jobs:
+  dep-guard:
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@d3fa20888fa2878e877e22bb7702141217290e7c  # main
+    permissions:
+      contents: read
+
   golangci-lint:
+    needs: [dep-guard]
     runs-on: ubuntu-latest
     steps:
       - name: use gh token
@@ -20,18 +27,18 @@ jobs:
           git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
       - name: "Checkout code on PR"
         if: github.event_name == 'pull_request'
-        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
+        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@d3fa20888fa2878e877e22bb7702141217290e7c  # main
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: "Checkout code on push"
         if: github.event_name == 'push'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9  # v8
         timeout-minutes: 20
         with:
           version: v2.5.0
@@ -41,7 +48,7 @@ jobs:
           args: --issues-exit-code=0 -v ./...
           skip-cache: false
           skip-save-cache: false
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: golangcilint-${{ github.run_id }}-${{ matrix.storagetype }}-${{ matrix.database }}-${{ matrix.version }}
           retention-days: 1
@@ -49,7 +56,7 @@ jobs:
 
   test:
     name: Tests ${{ matrix.storagetype }} storage - DB ${{ matrix.database }} ${{ matrix.version }} ${{ matrix.instancetype }}
-    needs: [golangci-lint]
+    needs: [dep-guard, golangci-lint]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -110,20 +117,20 @@ jobs:
     steps:
       - name: "Checkout PR"
         if: github.event_name == 'pull_request'
-        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
+        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@d3fa20888fa2878e877e22bb7702141217290e7c  # main
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: "Checkout code"
         if: github.event_name == 'push'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 1
           token: ${{ secrets.ORG_GH_TOKEN }}
           submodules: false
 
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495  # v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -134,7 +141,7 @@ jobs:
         run: go build -v ./...
 
       - name: Install Task
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@e26d8975574116b0097a1161e0fe16ba75d84c1c  # v1
         with:
           version: 3
 
@@ -156,7 +163,7 @@ jobs:
           DB_SETUP: ${{ matrix.instancetype }}
           DB_VERSION: ${{ matrix.version }}
         run: task test-${{ matrix.storagetype }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: coverage-${{ github.run_id }}-${{ matrix.storagetype }}-${{ matrix.instancetype }}-${{ matrix.database }}-${{ matrix.version }}.cov
           retention-days: 1
@@ -164,39 +171,39 @@ jobs:
 
   sonar-cloud-analysis:
     runs-on: ubuntu-latest
-    needs: [test, golangci-lint]
+    needs: [dep-guard, test, golangci-lint]
     steps:
       - name: "Checkout PR"
         if: github.event_name == 'pull_request'
-        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
+        uses: TykTechnologies/github-actions/.github/actions/checkout-pr@d3fa20888fa2878e877e22bb7702141217290e7c  # main
         with:
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: "Checkout code"
         if: github.event_name == 'push'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 1
           token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495  # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: ./downloaded-coverage
           merge-multiple: true
       - name: Download golangci-lint artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: .
           pattern: golangcilint-*
           merge-multiple: true
       - name: Check reports existence
         id: check_files
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@f02338908d150e00a4b8bebc2dad18bd9e5229b0  # v1
         with:
           files: "coverage/*.cov, golanglint.xml"
       - name: Install Dependencies
@@ -205,18 +212,18 @@ jobs:
         run: >
           git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
 
-          go install github.com/wadey/gocovmerge@latest
+          go install github.com/wadey/gocovmerge@b5bfa59ec0adc420475f97f89b58045c721d761c
       - name: Setup CI Tooling
-        uses: shrink/actions-docker-extract@v3
+        uses: shrink/actions-docker-extract@921bf17c6693530407a79458546c735d712a3216  # v3
         with:
-          image: tykio/ci-tools:latest
+          image: tykio/ci-tools:latest  # TODO: pin to digest once available
           path: /usr/local/bin/task
           destination: /usr/local/bin/
 
       - name: merge reports
         run: task merge-coverage
       - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: sonarsource/sonarcloud-github-action@ba3875ecf642b2129de2b589510c81a8b53dbf4e  # master
         with:
           args: >
             -Dsonar.organization=tyktechnologies

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -12,7 +12,7 @@ jobs:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f  # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN : ${{ secrets.ORG_GH_TOKEN}}
@@ -33,4 +33,3 @@ jobs:
           #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
           #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
           lock-pullrequest-aftermerge: false
-

--- a/.github/workflows/jira-pr-validator.yaml
+++ b/.github/workflows/jira-pr-validator.yaml
@@ -2,7 +2,7 @@ name: Validate PR against Jira
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, labeled]
 
 concurrency:
   group: jira-validator-${{ github.event.pull_request.number }}
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate Jira ticket
-        uses: TykTechnologies/jira-linter@main
+        uses: TykTechnologies/jira-linter@38a9cabef56171c4e52ea698fa7be3db5fca3a49  # main
         with:
           jira-base-url: 'https://tyktech.atlassian.net'
           jira-api-token: ${{ secrets.JIRA_TOKEN }}
-

--- a/.github/workflows/visor.yaml
+++ b/.github/workflows/visor.yaml
@@ -2,7 +2,7 @@ name: Visor
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
   issues:
     types: [opened]
   issue_comment:
@@ -19,19 +19,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       # Add this step to set up the Go environment
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: '1.21' # Or the version specified in go.mod
 
       # Add this step to download Go module dependencies
       - name: Download Go dependencies
         run: go mod download
-        
-      - uses: probelabs/visor@main
+
+      - uses: probelabs/visor@02e893ad11b66319b0fca1a43622038171c1a159  # main
         with:
           app-id: ${{ secrets.PROBE_APP_ID }}
           private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- **Pin all `uses:` to SHA-256**: Every GitHub Action reference across all 4 workflows (`ci-tests.yml`, `cla.yml`, `jira-pr-validator.yaml`, `visor.yaml`) is now pinned to a full 40-character commit SHA instead of mutable tags/branches.
- **Add dependency guard**: Added `dep-guard` job using `TykTechnologies/github-actions/.github/workflows/dependency-guard.yml` reusable workflow with `contents: read` permissions. All build jobs (`golangci-lint`, `test`, `sonar-cloud-analysis`) have `needs: [dep-guard]` to gate on dependency guard passing.
- **Add `labeled` trigger**: All `pull_request` event types now include `labeled` to support label-driven workflows.
- **Pin `go install` to commit SHA**: `gocovmerge@latest` changed to `gocovmerge@b5bfa59ec0adc420475f97f89b58045c721d761c`.
- **Docker image TODO**: Added `# TODO: pin to digest once available` comment for `tykio/ci-tools:latest` (digest not resolvable from CI).

### Actions pinned

| Action | SHA | Tag |
|--------|-----|-----|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4 |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4 |
| `actions/download-artifact` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4 |
| `actions/setup-go` | `be3c94b385c4f180051c996d336f57a34c397495` | v3 |
| `actions/setup-go` | `40f1582b2485089dde7abd97c1529aa768e1baff` | v5 |
| `golangci/golangci-lint-action` | `4afd733a84b1f43292c63897423277bb7f4313a9` | v8 |
| `arduino/setup-task` | `e26d8975574116b0097a1161e0fe16ba75d84c1c` | v1 |
| `andstor/file-existence-action` | `f02338908d150e00a4b8bebc2dad18bd9e5229b0` | v1 |
| `shrink/actions-docker-extract` | `921bf17c6693530407a79458546c735d712a3216` | v3 |
| `sonarsource/sonarcloud-github-action` | `ba3875ecf642b2129de2b589510c81a8b53dbf4e` | master |
| `contributor-assistant/github-action` | `b2a7f9fb90217ea0b8a0c95c288221457be4a31f` | v2.2.0 |
| `TykTechnologies/github-actions` | `d3fa20888fa2878e877e22bb7702141217290e7c` | main |
| `TykTechnologies/jira-linter` | `38a9cabef56171c4e52ea698fa7be3db5fca3a49` | main |
| `probelabs/visor` | `02e893ad11b66319b0fca1a43622038171c1a159` | main |

## Test plan

- [ ] Verify `dep-guard` job runs and passes on PR
- [ ] Verify `golangci-lint` job waits for `dep-guard` before running
- [ ] Verify `test` job waits for both `dep-guard` and `golangci-lint`
- [ ] Verify `sonar-cloud-analysis` waits for `dep-guard`, `test`, and `golangci-lint`
- [ ] Verify all SHA-pinned actions resolve correctly
- [ ] Verify `labeled` event type triggers workflows on label addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)