### PR TITLE
[TT-17030] Migrate workflow from PAT to GitHub App token

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -13,22 +13,30 @@ jobs:
   golangci-lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: use gh token
         env:
-          TOKEN: "${{ secrets.ORG_GH_TOKEN }}"
+          TOKEN: "${{ steps.app-token.outputs.token }}"
         run: >
           git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
       - name: "Checkout code on PR"
         if: github.event_name == 'pull_request'
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: "Checkout code on push"
         if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
@@ -108,18 +116,26 @@ jobs:
             instancetype: TLS
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: "Checkout PR"
         if: github.event_name == 'pull_request'
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: "Checkout code"
         if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           submodules: false
 
       - name: Setup Golang
@@ -166,18 +182,26 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, golangci-lint]
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: "Checkout PR"
         if: github.event_name == 'pull_request'
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: "Checkout code"
         if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Golang
         uses: actions/setup-go@v3
@@ -201,7 +225,7 @@ jobs:
           files: "coverage/*.cov, golanglint.xml"
       - name: Install Dependencies
         env:
-          TOKEN: "${{ secrets.ORG_GH_TOKEN }}"
+          TOKEN: "${{ steps.app-token.outputs.token }}"
         run: >
           git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
 


### PR DESCRIPTION
## Summary
- Replace `ORG_GH_TOKEN` (PAT) with GitHub App token (`actions/create-github-app-token`) in `ci-tests.yml`
- All three jobs (`golangci-lint`, `test`, `sonar-cloud-analysis`) now generate their own app token as the first step
- Token is used for `git config` (private Go module access) and `actions/checkout` / `checkout-pr` steps

## Test plan
- [ ] Verify the `golangci-lint` job runs successfully with the new token
- [ ] Verify the `test` job matrix runs can checkout and build
- [ ] Verify the `sonar-cloud-analysis` job can install private Go dependencies via `git config`
- [ ] Confirm `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` secrets are configured in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)