### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           TOKEN: "${{ steps.app-token.outputs.token }}"
         run: >
-          git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: "Checkout code on PR"
         if: github.event_name == 'pull_request'
         uses: TykTechnologies/github-actions/.github/actions/checkout-pr@main
@@ -227,7 +227,7 @@ jobs:
         env:
           TOKEN: "${{ steps.app-token.outputs.token }}"
         run: >
-          git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
 
           go install github.com/wadey/gocovmerge@latest
       - name: Setup CI Tooling


### PR DESCRIPTION
## Summary
- Replace `url."https://${TOKEN}@github.com".insteadOf` with `url."https://x-access-token:${TOKEN}@github.com/".insteadOf` in ci-tests.yml (2 occurrences)
- The bare token format doesn't work when `actions/checkout` has configured a credential helper; the `x-access-token:` prefix and trailing slashes fix this

## Test plan
- [ ] Verify CI tests workflow can pull private Go modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)