### PR TITLE
[TT-17569] Bump jackc/pgx/v5 to v5.9.2 (CVE-2026-41889)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/helloeave/json v1.15.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.9.1 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZ
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.3.0/go.mod h1:t3JDKnCBlYIc0ewLF0Q7B8MXmoIaBOZj/ic7iHozM/8=
-github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
-github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.0/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=


### PR DESCRIPTION
## What
Bumps `github.com/jackc/pgx/v5` v5.9.1 → v5.9.2 (indirect).

this was reported here: https://tyktechnologies.github.io/list-docker-cves/identity-broker/v1.7.3-rc3/

## Why
pgx v5.9.1 is affected by **CVE-2026-41889** — SQL injection when the non-default *simple*
protocol is used with a dollar-quoted string literal containing attacker-controlled text that
would be interpreted as a placeholder. Fixed in v5.9.2.

pgx is pulled in via storage's postgres support (`gorm.io/driver/postgres` → `pgx/v5`); the
v5.9.1 floor was set by this module's own `go.mod`, so the bump belongs here and propagates to
all consumers (TIB, portal, tyk-pump, tyk-sink, gateway, dashboard) on their next storage bump.

## Notes
- `go build ./...`, `go mod tidy`, and `go mod verify` all pass.
- Trivy (all severities) confirms CVE-2026-41889 is cleared after the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)