### PR TITLE
[TT-17611] Centralize IAM refresh parsing + fail fast on token mint

### DIFF
--- a/iamauth/gcp/provider.go
+++ b/iamauth/gcp/provider.go
@@ -60,6 +60,16 @@ func NewCredentialsProvider(ctx context.Context, cfg Config) (func(context.Conte
 	// before its actual expiry, giving us proactive rotation for free.
 	ts := oauth2.ReuseTokenSourceWithExpiry(nil, base, refresh)
 
+	// Fail fast: mint the first token now so IAM misconfiguration (missing
+	// permissions, an unreachable metadata server, a bad service account)
+	// surfaces here at startup with a clear error, instead of later as an
+	// opaque Redis AUTH failure on the first connection. The token is cached by
+	// the reuse source, so the first real connection reuses it rather than
+	// minting again.
+	if _, err := ts.Token(); err != nil {
+		return nil, fmt.Errorf("gcp iam: minting initial access token: %w", err)
+	}
+
 	return providerFromTokenSource(ts), nil
 }
 

--- a/iamauth/gcp/provider_hermetic_test.go
+++ b/iamauth/gcp/provider_hermetic_test.go
@@ -7,8 +7,11 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,13 +19,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// writeFakeADCFile writes a syntactically valid service-account key to a temp
-// file and points GOOGLE_APPLICATION_CREDENTIALS at it. The RSA key is generated
-// per-run, so no secret is committed. This lets the ADC and impersonation token
-// sources be constructed entirely offline (a token is only fetched lazily on
-// Token(), which these tests never call), exercising the wiring without touching
-// Google.
-func writeFakeADCFile(t *testing.T) {
+// fakeTokenServer returns a local HTTP server that answers OAuth2 token requests
+// so token minting runs entirely offline. It returns status for every request
+// (200 with a token to simulate success, or an error status to simulate an IAM
+// failure such as a missing permission) and a counter of how many requests it
+// received.
+func fakeTokenServer(t *testing.T, status int) (*httptest.Server, *int32) {
+	t.Helper()
+
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if _, err := w.Write([]byte(`{"access_token":"fake-token","token_type":"Bearer","expires_in":3600}`)); err != nil {
+			t.Errorf("writing token response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, &hits
+}
+
+// writeFakeADCFile writes a syntactically valid service-account key whose
+// token_uri points at tokenURI, then points GOOGLE_APPLICATION_CREDENTIALS at
+// it. The RSA key is generated per-run, so no secret is committed. With a local
+// tokenURI the whole flow — credential resolution and the token mint — runs
+// offline without touching Google.
+func writeFakeADCFile(t *testing.T, tokenURI string) {
 	t.Helper()
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -39,7 +71,7 @@ func writeFakeADCFile(t *testing.T) {
 		"private_key":  string(pemKey),
 		"client_email": "test@test-project.iam.gserviceaccount.com",
 		"client_id":    "1234567890",
-		"token_uri":    "https://oauth2.googleapis.com/token",
+		"token_uri":    tokenURI,
 	}
 
 	data, err := json.Marshal(sa)
@@ -52,7 +84,7 @@ func writeFakeADCFile(t *testing.T) {
 }
 
 func TestBaseTokenSource_ADC_Success(t *testing.T) {
-	writeFakeADCFile(t)
+	writeFakeADCFile(t, "https://oauth2.googleapis.com/token")
 
 	ts, err := baseTokenSource(context.Background(), "")
 	require.NoError(t, err)
@@ -60,7 +92,7 @@ func TestBaseTokenSource_ADC_Success(t *testing.T) {
 }
 
 func TestBaseTokenSource_Impersonation_Success(t *testing.T) {
-	writeFakeADCFile(t)
+	writeFakeADCFile(t, "https://oauth2.googleapis.com/token")
 
 	ts, err := baseTokenSource(context.Background(), "target@test-project.iam.gserviceaccount.com")
 	require.NoError(t, err)
@@ -85,23 +117,46 @@ func TestBaseTokenSource_Impersonation_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "impersonation")
 }
 
-func TestNewCredentialsProvider_DefaultRefresh(t *testing.T) {
-	writeFakeADCFile(t)
+// TestNewCredentialsProvider_MintsTokenEagerly proves the fail-fast behavior:
+// construction mints a token immediately (the local server is hit), and that
+// token is cached so the returned provider hands it out without a second mint.
+func TestNewCredentialsProvider_MintsTokenEagerly(t *testing.T) {
+	srv, hits := fakeTokenServer(t, http.StatusOK)
+	writeFakeADCFile(t, srv.URL)
 
 	provider, err := NewCredentialsProvider(context.Background(), Config{})
 	require.NoError(t, err)
-	assert.NotNil(t, provider)
+	require.NotNil(t, provider)
+	assert.Greater(t, atomic.LoadInt32(hits), int32(0), "NewCredentialsProvider must mint a token eagerly")
+
+	user, pass, err := provider(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "default", user)
+	assert.Equal(t, "fake-token", pass)
 }
 
 func TestNewCredentialsProvider_CustomRefresh(t *testing.T) {
-	writeFakeADCFile(t)
+	srv, _ := fakeTokenServer(t, http.StatusOK)
+	writeFakeADCFile(t, srv.URL)
 
 	provider, err := NewCredentialsProvider(context.Background(), Config{RefreshBeforeExpiry: time.Minute})
 	require.NoError(t, err)
 	assert.NotNil(t, provider)
 }
 
-func TestNewCredentialsProvider_Error(t *testing.T) {
+// TestNewCredentialsProvider_MintFailure proves that an IAM error surfaced while
+// minting the initial token fails construction, rather than being deferred to
+// the first Redis connection.
+func TestNewCredentialsProvider_MintFailure(t *testing.T) {
+	srv, _ := fakeTokenServer(t, http.StatusForbidden)
+	writeFakeADCFile(t, srv.URL)
+
+	_, err := NewCredentialsProvider(context.Background(), Config{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "token")
+}
+
+func TestNewCredentialsProvider_CredentialResolutionError(t *testing.T) {
 	t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(t.TempDir(), "does-not-exist.json"))
 
 	_, err := NewCredentialsProvider(context.Background(), Config{})

--- a/iamauth/provider.go
+++ b/iamauth/provider.go
@@ -13,6 +13,7 @@ package iamauth
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/TykTechnologies/storage/iamauth/gcp"
@@ -32,9 +33,11 @@ type Config struct {
 	// empty the workload's own identity is used (GKE Workload Identity or
 	// GOOGLE_APPLICATION_CREDENTIALS for GCP). Optional.
 	ServiceAccount string
-	// RefreshBeforeExpiry is how far ahead of expiry tokens are refreshed.
-	// Provider-specific default applies when zero. Optional.
-	RefreshBeforeExpiry time.Duration
+	// RefreshBeforeExpiry is how far ahead of expiry tokens are refreshed,
+	// expressed as a Go duration string (for example "5m"). This mirrors the
+	// consumer's raw config value so callers don't each re-implement parsing.
+	// Empty applies the provider-specific default. Optional.
+	RefreshBeforeExpiry string
 }
 
 // NewProvider builds the credentials provider for cfg.Provider, suitable for the
@@ -46,11 +49,34 @@ func NewProvider(ctx context.Context, cfg Config) (model.CredentialsProviderFunc
 	case "":
 		return nil, fmt.Errorf("iamauth: provider must be set")
 	case ProviderGCP:
+		refresh, err := parseRefreshBeforeExpiry(cfg.RefreshBeforeExpiry)
+		if err != nil {
+			return nil, err
+		}
+
 		return gcp.NewCredentialsProvider(ctx, gcp.Config{
 			ServiceAccount:      cfg.ServiceAccount,
-			RefreshBeforeExpiry: cfg.RefreshBeforeExpiry,
+			RefreshBeforeExpiry: refresh,
 		})
 	default:
 		return nil, fmt.Errorf("iamauth: unsupported provider %q", cfg.Provider)
 	}
+}
+
+// parseRefreshBeforeExpiry parses the optional refresh-before-expiry duration
+// string. An empty value yields a zero duration, letting the provider apply its
+// own default. Centralizing it here means Gateway, Pump, MDCB and Dashboard all
+// pass their raw config string straight through instead of each duplicating
+// this parse-and-default logic.
+func parseRefreshBeforeExpiry(raw string) (time.Duration, error) {
+	if strings.TrimSpace(raw) == "" {
+		return 0, nil
+	}
+
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("iamauth: invalid refresh_before_expiry %q: %w", raw, err)
+	}
+
+	return d, nil
 }

--- a/iamauth/provider_test.go
+++ b/iamauth/provider_test.go
@@ -3,6 +3,7 @@ package iamauth
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +21,35 @@ func TestNewProvider_UnsupportedProvider(t *testing.T) {
 	// The error must name the offending provider and flag it as unsupported.
 	assert.Contains(t, err.Error(), "azure")
 	assert.Contains(t, err.Error(), "unsupported")
+}
+
+func TestParseRefreshBeforeExpiry(t *testing.T) {
+	t.Run("empty yields zero and no error", func(t *testing.T) {
+		d, err := parseRefreshBeforeExpiry("  ")
+		require.NoError(t, err)
+		assert.Equal(t, time.Duration(0), d)
+	})
+
+	t.Run("valid duration is parsed", func(t *testing.T) {
+		d, err := parseRefreshBeforeExpiry("90s")
+		require.NoError(t, err)
+		assert.Equal(t, 90*time.Second, d)
+	})
+
+	t.Run("invalid duration errors with the offending value", func(t *testing.T) {
+		_, err := parseRefreshBeforeExpiry("nope")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nope")
+	})
+}
+
+func TestNewProvider_InvalidRefreshDuration(t *testing.T) {
+	// A malformed duration string must be rejected up front — before any
+	// credential resolution — with an error that names the offending value.
+	_, err := NewProvider(context.Background(), Config{Provider: "gcp", RefreshBeforeExpiry: "not-a-duration"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not-a-duration")
+	assert.Contains(t, err.Error(), "refresh_before_expiry")
 }
 
 func TestNewProvider_GCPRoutesToGCP(t *testing.T) {


### PR DESCRIPTION
## What
Two follow-up hardening changes to the IAM credentials provider added in #149 (v1.4.0), addressing review findings so downstream consumers don't duplicate logic:

1. **Centralized refresh-duration parsing.** `iamauth.Config.RefreshBeforeExpiry` changes from `time.Duration` to a **Go duration string** (e.g. `"5m"`), parsed inside `NewProvider`. It mirrors the consumers' raw config field (`token_refresh_before_expiry`), so Gateway/Pump/MDCB/Dashboard pass their string straight through instead of each re-implementing parse-and-default (which was duplicated in every component, and twice within the Gateway).

2. **Fail fast on token minting.** `gcp.NewCredentialsProvider` now mints the first token eagerly. IAM misconfiguration (missing permissions, unreachable metadata server, bad service account) now fails at startup with an explicit `gcp iam: minting initial access token: …` error instead of surfacing later as an opaque Redis `AUTH` failure. The token is cached by the reuse source, so the first real connection reuses it — no double mint.

## Why
Review feedback on the Gateway PR (#8402) flagged the duplicated `parseRefreshBeforeExpiry` helper and the lazy token mint. Fixing both in the storage library is the root-cause fix: it deletes the duplication at the source and gives every consumer clearer startup diagnostics.

## Notes
- **API change** to a field introduced only in v1.4.0 (`RefreshBeforeExpiry` type `time.Duration` → `string`); no external consumer has adopted v1.4.0 yet (all on local `replace`), so impact is nil. Will be released as **v1.4.1** and consumers pinned there.
- Hermetic tests exercise eager mint (success + failure) offline via a local token server — no Google contact.
- `iamauth` + `iamauth/gcp` remain at **100% coverage**; `golangci-lint` v2.5.0 clean; `go build ./...` / `go vet` pass.
- Code-only change — no `go.mod`/dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17611" title="TT-17611" target="_blank">TT-17611</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | [Innersource] IAM Auth for Redis/Valkey - GCP First |

Generated at: 2026-07-20 16:10:13

</details>

<!---TykTechnologies/jira-linter ends here-->
